### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "git commit -m \"update css file\""

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ JS | HTML | CSS
 ## Status
 
 [developing on repl.it]
+
+[![Run on Repl.it](https://repl.it/badge/github/Karytonn/Whatsapp-Link-Creator)](https://repl.it/github/Karytonn/Whatsapp-Link-Creator)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@karytonn/Whatsapp-Link-Creator-1).